### PR TITLE
Use `step.geometry` instead of `step.intersections` for AR lane

### DIFF
--- a/app/src/main/java/com/mapbox/vision/examples/activity/ar/ArNavigationActivity.kt
+++ b/app/src/main/java/com/mapbox/vision/examples/activity/ar/ArNavigationActivity.kt
@@ -13,6 +13,9 @@ import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.core.constants.Constants
+import com.mapbox.geojson.Point
+import com.mapbox.geojson.utils.PolylineUtils
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener
@@ -187,12 +190,13 @@ class ArNavigationActivity : AppCompatActivity(), RouteListener, ProgressChangeL
                 )
                 routePoints.add(maneuverPoint)
 
-                step.intersections()
-                    ?.map { intersection ->
+                step.geometry()
+                    ?.buildStepPointsFromGeometry()
+                    ?.map { geometryStep ->
                         RoutePoint(
                             GeoCoordinate(
-                                latitude = intersection.location().latitude(),
-                                longitude = intersection.location().longitude()
+                                latitude = geometryStep.latitude(),
+                                longitude = geometryStep.longitude()
                             )
                         )
                     }
@@ -203,5 +207,9 @@ class ArNavigationActivity : AppCompatActivity(), RouteListener, ProgressChangeL
         }
 
         return routePoints.toTypedArray()
+    }
+
+    private fun String.buildStepPointsFromGeometry(): List<Point> {
+        return PolylineUtils.decode(this, Constants.PRECISION_6);
     }
 }


### PR DESCRIPTION
This is how more points is retrieved from Route and so AR lane behaves much smoother