### PR TITLE
Teaser route fix

### DIFF
--- a/app/src/main/java/com/mapbox/vision/examples/activity/ar/ArMapActivity.kt
+++ b/app/src/main/java/com/mapbox/vision/examples/activity/ar/ArMapActivity.kt
@@ -84,7 +84,8 @@ class ArMapActivity : AppCompatActivity(), MapboxMap.OnMapClickListener, OnMapRe
             if (currentRoute == null) {
                 Toast.makeText(this, "Route is not ready yet!", Toast.LENGTH_LONG).show()
             } else {
-                ArNavigationActivity.start(this, currentRoute!!)
+                ArNavigationActivity.directionsRoute = currentRoute
+                ArNavigationActivity.start(this)
             }
         }
     }

--- a/app/src/main/java/com/mapbox/vision/examples/activity/ar/ArNavigationActivity.kt
+++ b/app/src/main/java/com/mapbox/vision/examples/activity/ar/ArNavigationActivity.kt
@@ -43,15 +43,13 @@ class ArNavigationActivity : AppCompatActivity(), RouteListener, ProgressChangeL
     companion object {
         private var TAG = ArNavigationActivity::class.java.simpleName
 
-        private const val EXTRA_ROUTE = "Route"
         private const val LOCATION_INTERVAL_DEFAULT = 0L
         private const val LOCATION_INTERVAL_FAST = 1000L
 
-        fun start(context: Activity, directionsRoute: DirectionsRoute) {
-            context.startActivity(
-                Intent(context, ArNavigationActivity::class.java)
-                    .putExtra(EXTRA_ROUTE, directionsRoute)
-            )
+        var directionsRoute: DirectionsRoute? = null
+
+        fun start(context: Activity) {
+            context.startActivity(Intent(context, ArNavigationActivity::class.java))
         }
     }
 
@@ -61,9 +59,9 @@ class ArNavigationActivity : AppCompatActivity(), RouteListener, ProgressChangeL
 
     private val arLocationEngineRequest by lazy {
         LocationEngineRequest.Builder(LOCATION_INTERVAL_DEFAULT)
-                .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
-                .setFastestInterval(LOCATION_INTERVAL_FAST)
-                .build()
+            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+            .setFastestInterval(LOCATION_INTERVAL_FAST)
+            .build()
     }
 
     private lateinit var mapboxNavigation: MapboxNavigation
@@ -122,7 +120,14 @@ class ArNavigationActivity : AppCompatActivity(), RouteListener, ProgressChangeL
 
         VisionArManager.create(VisionManager, mapbox_ar_view)
 
-        setRoute(intent.getSerializableExtra(EXTRA_ROUTE) as DirectionsRoute)
+        directionsRoute.let {
+            if (it == null) {
+                Toast.makeText(this, "Route is not set!", Toast.LENGTH_LONG).show()
+                finish()
+            } else {
+                setRoute(it)
+            }
+        }
     }
 
     override fun onPause() {
@@ -180,7 +185,7 @@ class ArNavigationActivity : AppCompatActivity(), RouteListener, ProgressChangeL
 
     private fun DirectionsRoute.getRoutePoints(): Array<RoutePoint> {
         val routePoints = arrayListOf<RoutePoint>()
-        legs()?.forEach {leg ->
+        legs()?.forEach { leg ->
             leg.steps()?.forEach { step ->
                 val maneuverPoint = RoutePoint(
                     GeoCoordinate(

--- a/app/src/main/res/layout/activity_ar_map.xml
+++ b/app/src/main/res/layout/activity_ar_map.xml
@@ -36,6 +36,7 @@
         android:layout_width="87dp"
         android:layout_height="44dp"
         android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
         android:layout_margin="18dp"
         android:background="@drawable/bg_label"
         android:backgroundTint="@color/blue"


### PR DESCRIPTION
Long routes can't be passed inside intents (they are too big), we can use static var.
Also moved `GO` button to the bottom because it hides _compass_ button.

closes #116 