### PR TITLE
Add new SignTypes

### DIFF
--- a/common/src/main/java/com/mapbox/vision/common/models/UiSign.kt
+++ b/common/src/main/java/com/mapbox/vision/common/models/UiSign.kt
@@ -428,7 +428,20 @@ sealed class UiSign {
         AheadSpeedLimit(usResourceName = "ahead_speedlimit", hasNumber = true),
         WarningSpeedLimit(usResourceName = "warning_speedlimit", hasNumber = true),
         RegulatoryNoUTurnRight(usResourceName = "regulatory_no_u_turn_right"),
-        WarningTurnRightOnlyArrow(usResourceName = "warning_turn_right_only_arrow")
+        WarningTurnRightOnlyArrow(usResourceName = "warning_turn_right_only_arrow"),
+
+        InformationCarWashing,
+        InformationBusStop,
+        RegulatoryPedestriansCrossingUp,
+        RegulatoryPedestriansCrossingDown,
+        InformationAutoService,
+        InformationFood,
+        InformationTown,
+        InformationTownEnd,
+        RegulatoryControl,
+        RegulatoryDoubleUTurn,
+        SpeedLimitZone,
+        SpeedLimitEndZone
     }
 
     @Suppress("EnumEntryName")


### PR DESCRIPTION
EU classifier was updated, new SignTypes added.
Teaser should also handle it.
Assets for new signs are not ready yet.

Linked issues: [1757](https://app.zenhub.com/workspaces/vision-sdk-5ca52e6c027e3e7234ac7512/issues/mapbox/mapbox-vision/1757)