### PR TITLE
Improve repo build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Setup:
 1. `git clone -b master git@github.com:mapbox/mapbox-vision-android-teaser.git`
 1. Sign up or log in to your Mapbox account and grab a [Mapbox access token](https://www.mapbox.com/help/define-access-token/)
 1. Set your Mapbox token as environmental variable `MAPBOX_ACCESS_TOKEN`
-
+1. Set your [Maven credentials](https://vision.mapbox.com/install/)
 
  Build:
 1. `Teaser`: Build && run the `app` module
 1. `Session Recorder`: Build && run the `recorder` module
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,13 @@
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 apply from: '../gradle/generate-token.gradle'
 apply from: "../gradle/ktlint.gradle"
+
+if (gradle.ext.hasProperty('BUILD_CORE_FROM_SOURCE')) {
+    apply plugin: 'io.fabric'
+}
 
 android {
     buildToolsVersion build_tools_version

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 apply from: '../gradle/generate-token.gradle'
 apply from: "../gradle/ktlint.gradle"
 
-if (gradle.ext.hasProperty('BUILD_CORE_FROM_SOURCE')) {
+if (gradle.ext.has('BUILD_CORE_FROM_SOURCE')) {
     apply plugin: 'io.fabric'
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     api "androidx.core:core-ktx:$android_x_ktx"
     api "androidx.multidex:multidex:$android_x_multidex"
 
-    if (gradle.ext.hasProperty('BUILD_CORE_FROM_SOURCE') && gradle.ext.BUILD_CORE_FROM_SOURCE.toBoolean()) {
+    if (gradle.ext.has('BUILD_CORE_FROM_SOURCE') && gradle.ext.BUILD_CORE_FROM_SOURCE.toBoolean()) {
         api project(path: ':Vision')
         api project(path: ':VisionAr')
         api project(path: ':VisionSafety')

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     api "androidx.core:core-ktx:$android_x_ktx"
     api "androidx.multidex:multidex:$android_x_multidex"
 
-    if (gradle.ext.BUILD_CORE_FROM_SOURCE.toBoolean()) {
+    if (gradle.ext.hasProperty('BUILD_CORE_FROM_SOURCE') && gradle.ext.BUILD_CORE_FROM_SOURCE.toBoolean()) {
         api project(path: ':Vision')
         api project(path: ':VisionAr')
         api project(path: ':VisionSafety')

--- a/gradle/generate-token.gradle
+++ b/gradle/generate-token.gradle
@@ -2,22 +2,32 @@
 // Configuration file for adding a developer-config.xml containing the MAPBOX_ACCESS_TOKEN env. variable.
 //
 task accessToken {
+    def tokenDir = new File("${projectDir}/src/main/res/values")
+    if (!tokenDir.exists()) {
+        tokenDir.mkdir()
+    }
     def tokenFile = new File("${projectDir}/src/main/res/values/developer-config.xml")
+    String token
     if (!tokenFile.exists()) {
-        String envToken = "$System.env.MAPBOX_ACCESS_TOKEN"
-        if (envToken == "null") {
-            envToken = "YOUR_MAPBOX_ACCESS_TOKEN_GOES_HERE"
+        // check env
+        token = "$System.env.MAPBOX_ACCESS_TOKEN"
+        if (token == "null") {
+            token = ""
         }
         String tokenFileContents = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<!-- Please put your MAPBOX_ACCESS_TOKEN here -->\n" +
                 "<resources>\n" +
-                "    <string name=\"mapbox_access_token\">" + envToken + "</string>\n" +
+                "    <string name=\"mapbox_access_token\">" + token + "</string>\n" +
                 "</resources>"
-
-        if (tokenFileContents == null) {
-            throw new InvalidUserDataException("You haven't set the MAPBOX_ACCESS_TOKEN environment variable. " +
-                    "Replace YOUR_MAPBOX_ACCESS_TOKEN_GOES_HERE in /src/main/res/values/developer-config.xml")
-        }
         tokenFile.write(tokenFileContents)
+    } else {
+        def startPos = tokenFile.text.indexOf("mapbox_access_token") + "mapbox_access_token".length() + 2
+        def endPos = tokenFile.text.indexOf("<", startPos)
+        token = tokenFile.text.substring(startPos, endPos)
+    }
+    if (token == "") {
+        throw new InvalidUserDataException("You haven't set MAPBOX_ACCESS_TOKEN.\n" +
+                "Please set it in <module>/src/main/res/values/developer-config.xml")
     }
 }
 

--- a/gradle/generate-token.gradle
+++ b/gradle/generate-token.gradle
@@ -2,13 +2,20 @@
 // Configuration file for adding a developer-config.xml containing the MAPBOX_ACCESS_TOKEN env. variable.
 //
 task accessToken {
-    def tokenDir = new File("${projectDir}/src/main/res/values")
+    final TOKEN_DIR = "/src/main/res/values"
+    final MAPBOX_ACCESS_TOKEN = "mapbox_access_token"
+
+    def tokenDir = new File("${projectDir}" + TOKEN_DIR)
     if (!tokenDir.exists()) {
         tokenDir.mkdir()
     }
-    def tokenFile = new File("${projectDir}/src/main/res/values/developer-config.xml")
+    def tokenFile = new File("${projectDir}" + TOKEN_DIR + "/developer-config.xml")
     String token
-    if (!tokenFile.exists()) {
+    if (tokenFile.exists()) {
+        def startPos = tokenFile.text.indexOf(MAPBOX_ACCESS_TOKEN) + MAPBOX_ACCESS_TOKEN.length() + 2
+        def endPos = tokenFile.text.indexOf("<", startPos)
+        token = tokenFile.text.substring(startPos, endPos)
+    } else {
         // check env
         token = "$System.env.MAPBOX_ACCESS_TOKEN"
         if (token == "null") {
@@ -17,13 +24,9 @@ task accessToken {
         String tokenFileContents = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
                 "<!-- Please put your MAPBOX_ACCESS_TOKEN here -->\n" +
                 "<resources>\n" +
-                "    <string name=\"mapbox_access_token\">" + token + "</string>\n" +
+                "    <string name=\"" + MAPBOX_ACCESS_TOKEN + "\">" + token + "</string>\n" +
                 "</resources>"
         tokenFile.write(tokenFileContents)
-    } else {
-        def startPos = tokenFile.text.indexOf("mapbox_access_token") + "mapbox_access_token".length() + 2
-        def endPos = tokenFile.text.indexOf("<", startPos)
-        token = tokenFile.text.substring(startPos, endPos)
     }
     if (token == "") {
         throw new InvalidUserDataException("You haven't set MAPBOX_ACCESS_TOKEN.\n" +

--- a/recorder/build.gradle
+++ b/recorder/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 apply from: "../gradle/ktlint.gradle"
+apply from: '../gradle/generate-token.gradle'
 
 android {
     buildToolsVersion build_tools_version

--- a/replayer/build.gradle
+++ b/replayer/build.gradle
@@ -1,10 +1,13 @@
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 apply from: '../gradle/generate-token.gradle'
 apply from: "../gradle/ktlint.gradle"
+
+if (gradle.ext.hasProperty('BUILD_CORE_FROM_SOURCE')) {
+    apply plugin: 'io.fabric'
+}
 
 android {
     buildToolsVersion build_tools_version

--- a/replayer/build.gradle
+++ b/replayer/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 apply from: '../gradle/generate-token.gradle'
 apply from: "../gradle/ktlint.gradle"
 
-if (gradle.ext.hasProperty('BUILD_CORE_FROM_SOURCE')) {
+if (gradle.ext.has('BUILD_CORE_FROM_SOURCE')) {
     apply plugin: 'io.fabric'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ if (localPropsFile.exists()) {
     throw new IllegalStateException("local.properties could not be located for build process")
 }
 
-if (gradle.ext.BUILD_CORE_FROM_SOURCE.toBoolean()) {
+if (gradle.ext.hasProperty('BUILD_CORE_FROM_SOURCE') && gradle.ext.BUILD_CORE_FROM_SOURCE.toBoolean()) {
     include ':Vision'
     project(':Vision').projectDir = new File("./source/mapbox-vision/SDK/Platforms/Android/sdk")
     include ':VisionSafety'

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ if (localPropsFile.exists()) {
     throw new IllegalStateException("local.properties could not be located for build process")
 }
 
-if (gradle.ext.hasProperty('BUILD_CORE_FROM_SOURCE') && gradle.ext.BUILD_CORE_FROM_SOURCE.toBoolean()) {
+if (gradle.ext.has('BUILD_CORE_FROM_SOURCE') && gradle.ext.BUILD_CORE_FROM_SOURCE.toBoolean()) {
     include ':Vision'
     project(':Vision').projectDir = new File("./source/mapbox-vision/SDK/Platforms/Android/sdk")
     include ':VisionSafety'


### PR DESCRIPTION
1) Do not crash on absence of `BUILD_FROM_SOURCE` flag
2) Do not crash on Fabric - we apply Fabric only if we have `BUILD_FROM_SOURCE` flag
3) Crash on Gradle sync if `mapbox_access_token` is not specified.
