### PR TITLE
Add route selection before Recording

### DIFF
--- a/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
@@ -576,21 +576,30 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
         VisionReplayManager.destroy()
     }
 
-    private fun showReplayModeFragment() {
-        supportFragmentManager
+    private fun showReplayModeFragment(stateLoss: Boolean = false) {
+        val fragmentTransaction = supportFragmentManager
                 .beginTransaction()
                 .replace(R.id.fragment_container, ReplayModeFragment.newInstance(BASE_SESSION_PATH), ReplayModeFragment.TAG)
                 .addToBackStack(ReplayModeFragment.TAG)
-                .commit()
+
+        if (stateLoss) {
+            fragmentTransaction.commitAllowingStateLoss()
+        } else {
+            fragmentTransaction.commit()
+        }
         hideDashboardView()
     }
 
-    private fun showRecordingFragment(jsonRoute: String?) {
-        supportFragmentManager
+    private fun showRecorderFragment(jsonRoute: String?, stateLoss: Boolean = false) {
+        val fragmentTransaction = supportFragmentManager
                 .beginTransaction()
                 .replace(R.id.fragment_container, RecorderFragment.newInstance(BASE_SESSION_PATH, jsonRoute), RecorderFragment.TAG)
                 .addToBackStack(RecorderFragment.TAG)
-                .commitAllowingStateLoss()
+        if (stateLoss) {
+            fragmentTransaction.commitAllowingStateLoss()
+        } else {
+            fragmentTransaction.commit()
+        }
         hideDashboardView()
     }
 
@@ -708,7 +717,9 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
                 val jsonRoute = data?.getStringExtra(ArMapActivity.ARG_RESULT_JSON_ROUTE)
                 onSelectCamera()
                 vision_view.visualizationMode = VisualizationMode.Clear
-                showRecordingFragment(jsonRoute)
+
+                // Using state loss here to keep code simple, lost of RecorderFragment is not critical for UX
+                showRecorderFragment(jsonRoute, stateLoss = true)
             }
             else -> super.onActivityResult(requestCode, resultCode, data)
         }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
@@ -39,12 +39,12 @@ import com.mapbox.vision.performance.ModelPerformance
 import com.mapbox.vision.performance.ModelPerformanceMode
 import com.mapbox.vision.performance.ModelPerformanceRate
 import com.mapbox.vision.safety.VisionSafetyManager
-import com.mapbox.vision.teaser.MainActivity.VisionMode.Camera
-import com.mapbox.vision.teaser.MainActivity.VisionMode.Replay
 import com.mapbox.vision.safety.core.VisionSafetyListener
 import com.mapbox.vision.safety.core.models.CollisionDangerLevel
 import com.mapbox.vision.safety.core.models.CollisionObject
 import com.mapbox.vision.safety.core.models.RoadRestrictions
+import com.mapbox.vision.teaser.MainActivity.VisionMode.Camera
+import com.mapbox.vision.teaser.MainActivity.VisionMode.Replay
 import com.mapbox.vision.teaser.ar.ArMapActivity
 import com.mapbox.vision.teaser.ar.ArNavigationActivity
 import com.mapbox.vision.teaser.models.UiSign
@@ -662,9 +662,9 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
     }
 
     override fun onRequestPermissionsResult(
-            requestCode: Int,
-            permissions: Array<out String>,
-            grantResults: IntArray
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         if (allPermissionsGranted() && requestCode == PERMISSIONS_REQUEST_CODE) {

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.core.view.setPadding
+import androidx.fragment.app.Fragment
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants
 import com.mapbox.services.android.navigation.v5.utils.DistanceFormatter
 import com.mapbox.services.android.navigation.v5.utils.LocaleUtils
@@ -575,23 +576,19 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
     }
 
     private fun showReplayModeFragment(stateLoss: Boolean = false) {
-        val fragmentTransaction = supportFragmentManager
-                .beginTransaction()
-                .replace(R.id.fragment_container, ReplayModeFragment.newInstance(BASE_SESSION_PATH), ReplayModeFragment.TAG)
-                .addToBackStack(ReplayModeFragment.TAG)
-
-        if (stateLoss) {
-            fragmentTransaction.commitAllowingStateLoss()
-        } else {
-            fragmentTransaction.commit()
-        }
-        hideDashboardView()
+        val fragment = ReplayModeFragment.newInstance(BASE_SESSION_PATH)
+        showFragment(fragment, ReplayModeFragment.TAG, stateLoss)
     }
 
     private fun showRecorderFragment(jsonRoute: String?, stateLoss: Boolean = false) {
+        val fragment = RecorderFragment.newInstance(BASE_SESSION_PATH, jsonRoute)
+        showFragment(fragment, RecorderFragment.TAG, stateLoss)
+    }
+
+    private fun showFragment(fragment: Fragment, tag: String, stateLoss: Boolean = false) {
         val fragmentTransaction = supportFragmentManager
                 .beginTransaction()
-                .replace(R.id.fragment_container, RecorderFragment.newInstance(BASE_SESSION_PATH, jsonRoute), RecorderFragment.TAG)
+                .replace(R.id.fragment_container, fragment, RecorderFragment.TAG)
                 .addToBackStack(RecorderFragment.TAG)
         if (stateLoss) {
             fragmentTransaction.commitAllowingStateLoss()
@@ -644,13 +641,16 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
     }
 
     private fun startArMapActivityForNavigation() {
-        val intent = Intent(this@MainActivity, ArMapActivity::class.java)
-        startActivityForResult(intent, START_AR_MAP_ACTIVITY_FOR_NAVIGATION_RESULT_CODE)
+        startArMapActivity(START_AR_MAP_ACTIVITY_FOR_NAVIGATION_RESULT_CODE)
     }
 
     private fun startArMapActivityForRecording() {
+        startArMapActivity(START_AR_MAP_ACTIVITY_FOR_RECORDING_RESULT_CODE)
+    }
+
+    private fun startArMapActivity(resultCode: Int) {
         val intent = Intent(this@MainActivity, ArMapActivity::class.java)
-        startActivityForResult(intent, START_AR_MAP_ACTIVITY_FOR_RECORDING_RESULT_CODE)
+        startActivityForResult(intent, resultCode)
     }
 
     private fun startArSession() {

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
@@ -45,8 +45,6 @@ import com.mapbox.vision.safety.core.VisionSafetyListener
 import com.mapbox.vision.safety.core.models.CollisionDangerLevel
 import com.mapbox.vision.safety.core.models.CollisionObject
 import com.mapbox.vision.safety.core.models.RoadRestrictions
-import com.mapbox.vision.teaser.MainActivity.VisionManagerMode.Camera
-import com.mapbox.vision.teaser.MainActivity.VisionManagerMode.Replay
 import com.mapbox.vision.teaser.ar.ArMapActivity
 import com.mapbox.vision.teaser.ar.ArNavigationActivity
 import com.mapbox.vision.teaser.models.UiSign
@@ -715,7 +713,7 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
             }
             START_AR_MAP_ACTIVITY_FOR_RECORDING_RESULT_CODE -> {
                 val jsonRoute = data?.getStringExtra(ArMapActivity.ARG_RESULT_JSON_ROUTE)
-                onSelectCamera()
+                onCameraSelected()
                 vision_view.visualizationMode = VisualizationMode.Clear
 
                 // Using state loss here to keep code simple, lost of RecorderFragment is not critical for UX

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArMapActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArMapActivity.kt
@@ -1,6 +1,7 @@
 package com.mapbox.vision.teaser.ar
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -37,6 +38,7 @@ class ArMapActivity : AppCompatActivity(), MapboxMap.OnMapClickListener, OnMapRe
     companion object {
         private val TAG = ArMapActivity::class.java.simpleName
         private const val MAP_STYLE = "mapbox://styles/mapbox/dark-v10"
+        const val ARG_RESULT_JSON_ROUTE = "ARG_RESULT_JSON_ROUTE"
     }
 
     private var originPoint: Point? = null
@@ -81,11 +83,15 @@ class ArMapActivity : AppCompatActivity(), MapboxMap.OnMapClickListener, OnMapRe
         }
         mapView.onCreate(savedInstanceState)
         start_ar.setOnClickListener {
-            if (currentRoute == null) {
-                Toast.makeText(this, "Route is not ready yet!", Toast.LENGTH_LONG).show()
+            val route = currentRoute
+            if (route != null) {
+                val jsonRoute = route.toJson()
+                val data = Intent();
+                data.putExtra(ARG_RESULT_JSON_ROUTE, jsonRoute)
+                setResult(RESULT_OK, data);
+                finish()
             } else {
-                ArNavigationActivity.directionsRoute = currentRoute
-                ArNavigationActivity.start(this)
+                Toast.makeText(this, "Route is not ready yet!", Toast.LENGTH_LONG).show()
             }
         }
     }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArMapActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArMapActivity.kt
@@ -86,9 +86,9 @@ class ArMapActivity : AppCompatActivity(), MapboxMap.OnMapClickListener, OnMapRe
             val route = currentRoute
             if (route != null) {
                 val jsonRoute = route.toJson()
-                val data = Intent();
+                val data = Intent()
                 data.putExtra(ARG_RESULT_JSON_ROUTE, jsonRoute)
-                setResult(RESULT_OK, data);
+                setResult(RESULT_OK, data)
                 finish()
             } else {
                 Toast.makeText(this, "Route is not ready yet!", Toast.LENGTH_LONG).show()

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArMapActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArMapActivity.kt
@@ -86,8 +86,9 @@ class ArMapActivity : AppCompatActivity(), MapboxMap.OnMapClickListener, OnMapRe
             val route = currentRoute
             if (route != null) {
                 val jsonRoute = route.toJson()
-                val data = Intent()
-                data.putExtra(ARG_RESULT_JSON_ROUTE, jsonRoute)
+                val data = Intent().apply {
+                    putExtra(ARG_RESULT_JSON_ROUTE, jsonRoute)
+                }
                 setResult(RESULT_OK, data)
                 finish()
             } else {

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArNavigationActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArNavigationActivity.kt
@@ -23,8 +23,6 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
 import com.mapbox.vision.VisionManager
 import com.mapbox.vision.ar.VisionArManager
 import com.mapbox.vision.ar.core.models.Route
-import com.mapbox.vision.ar.core.models.RoutePoint
-import com.mapbox.vision.mobile.core.models.position.GeoCoordinate
 import com.mapbox.vision.performance.ModelPerformance
 import com.mapbox.vision.performance.ModelPerformanceConfig
 import com.mapbox.vision.performance.ModelPerformanceMode

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArNavigationActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArNavigationActivity.kt
@@ -27,6 +27,8 @@ import com.mapbox.vision.performance.ModelPerformance
 import com.mapbox.vision.performance.ModelPerformanceConfig
 import com.mapbox.vision.performance.ModelPerformanceMode
 import com.mapbox.vision.performance.ModelPerformanceRate
+import com.mapbox.vision.teaser.R
+import com.mapbox.vision.teaser.models.ArFeature
 import com.mapbox.vision.teaser.utils.getRoutePoints
 import com.mapbox.vision.utils.VisionLogger
 import kotlinx.android.synthetic.main.activity_ar_navigation.*

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArNavigationActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArNavigationActivity.kt
@@ -203,6 +203,4 @@ class ArNavigationActivity : AppCompatActivity(), RouteListener, ProgressChangeL
     override fun userOffRoute(location: Location?) {
         routeFetcher.findRouteFromRouteProgress(location, lastRouteProgress)
     }
-
-
 }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArNavigationActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/ar/ArNavigationActivity.kt
@@ -45,8 +45,9 @@ class ArNavigationActivity : AppCompatActivity(), RouteListener, ProgressChangeL
         private const val ARG_INPUT_JSON_ROUTE = "ARG_INPUT_JSON_ROUTE"
 
         fun start(context: Activity, jsonRoute: String) {
-            val intent = Intent(context, ArNavigationActivity::class.java)
-            intent.putExtra(ARG_INPUT_JSON_ROUTE, jsonRoute)
+            val intent = Intent(context, ArNavigationActivity::class.java).apply {
+                putExtra(ARG_INPUT_JSON_ROUTE, jsonRoute)
+            }
             context.startActivity(intent)
         }
     }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/recorder/RecorderFragment.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/recorder/RecorderFragment.kt
@@ -5,11 +5,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.vision.VisionManager
+import com.mapbox.vision.ar.VisionArManager
+import com.mapbox.vision.ar.core.models.Route
+import com.mapbox.vision.ar.core.models.RoutePoint
+import com.mapbox.vision.teaser.OnBackPressedListener
 import com.mapbox.vision.teaser.R
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.mapbox.vision.teaser.utils.getRoutePoints
 import kotlinx.android.synthetic.main.fragment_recorder.*
 
 class RecorderFragment : Fragment() {
@@ -20,20 +26,30 @@ class RecorderFragment : Fragment() {
         private fun buildFileName() = dateFormat.format(Date(System.currentTimeMillis()))
 
         private const val ARG_PARAM_SESSIONS_PATH = "ARG_PARAM_SESSIONS_PATH"
+		private const val ARG_PARAM_JSON_ROUTE = "ARG_PARAM_JSON_ROUTE"
         val TAG: String = RecorderFragment::class.java.simpleName
 
-        fun newInstance(sessionsPath: String) = RecorderFragment().apply {
+        fun newInstance(sessionsPath: String, jsonRoute: String?) = RecorderFragment().apply {
             arguments = Bundle().apply {
                 putString(ARG_PARAM_SESSIONS_PATH, sessionsPath)
+				putString(ARG_PARAM_JSON_ROUTE, jsonRoute)
             }
         }
     }
 
-    private var baseSessionsPath: String? = ""
+    private lateinit var baseSessionsPath: String
+    private var routePoints: Array<RoutePoint> = arrayOf()
+    private var directionsRoute: DirectionsRoute? = null
+    private var isArManagerInitiated = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        baseSessionsPath = arguments?.getString(ARG_PARAM_SESSIONS_PATH)
-        return if (baseSessionsPath.isNullOrEmpty().not()) {
+        baseSessionsPath = arguments?.getString(ARG_PARAM_SESSIONS_PATH) ?: ""
+        return if (baseSessionsPath.isNotEmpty()) {
+            val jsonRoute = arguments?.getString(ARG_PARAM_JSON_ROUTE)
+            if (jsonRoute != null) {
+                directionsRoute =  DirectionsRoute.fromJson(jsonRoute)
+                routePoints = directionsRoute?.getRoutePoints() ?: arrayOf()
+            }
             inflater.inflate(R.layout.fragment_recorder, container, false)
         } else {
             requireActivity().onBackPressed()
@@ -46,20 +62,39 @@ class RecorderFragment : Fragment() {
         initStopRecordButton()
     }
 
+    private fun initStopRecordButton() {
+        stop_record.setOnClickListener {
+            VisionManager.stopRecording()
+            requireActivity().onBackPressed()
+        }
+    }
+
     override fun onResume() {
         super.onResume()
+        onResumeARManager()
         VisionManager.startRecording("$baseSessionsPath/${buildFileName()}")
     }
 
     override fun onPause() {
         super.onPause()
+        onPauseARManager()
         VisionManager.stopRecording()
     }
 
-    private fun initStopRecordButton() {
-        stop_record.setOnClickListener {
-            VisionManager.stopRecording()
-            requireActivity().onBackPressed()
+    private fun onResumeARManager() {
+        val routeEta = directionsRoute?.duration()?.toFloat() ?: 0f
+        isArManagerInitiated = routePoints.isNotEmpty() && routeEta != 0f
+        if (isArManagerInitiated) {
+            VisionArManager.create(VisionManager)
+            val arRoute = Route(points = routePoints, eta = routeEta)
+            VisionArManager.setRoute(arRoute)
+        }
+    }
+
+    private fun onPauseARManager() {
+        if (isArManagerInitiated) {
+            isArManagerInitiated = false
+            VisionArManager.destroy()
         }
     }
 }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/recorder/RecorderFragment.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/recorder/RecorderFragment.kt
@@ -70,17 +70,17 @@ class RecorderFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        onResumeARManager()
+        onResumeArManager()
         VisionManager.startRecording("$baseSessionsPath/${buildFileName()}")
     }
 
     override fun onPause() {
         super.onPause()
-        onPauseARManager()
+        onPauseArManager()
         VisionManager.stopRecording()
     }
 
-    private fun onResumeARManager() {
+    private fun onResumeArManager() {
         val routeEta = directionsRoute?.duration()?.toFloat() ?: 0f
         isArManagerInitiated = routePoints.isNotEmpty() && routeEta != 0f
         if (isArManagerInitiated) {
@@ -90,7 +90,7 @@ class RecorderFragment : Fragment() {
         }
     }
 
-    private fun onPauseARManager() {
+    private fun onPauseArManager() {
         if (isArManagerInitiated) {
             isArManagerInitiated = false
             VisionArManager.destroy()

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/recorder/RecorderFragment.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/recorder/RecorderFragment.kt
@@ -10,12 +10,11 @@ import com.mapbox.vision.VisionManager
 import com.mapbox.vision.ar.VisionArManager
 import com.mapbox.vision.ar.core.models.Route
 import com.mapbox.vision.ar.core.models.RoutePoint
-import com.mapbox.vision.teaser.OnBackPressedListener
 import com.mapbox.vision.teaser.R
+import com.mapbox.vision.teaser.utils.getRoutePoints
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import com.mapbox.vision.teaser.utils.getRoutePoints
 import kotlinx.android.synthetic.main.fragment_recorder.*
 
 class RecorderFragment : Fragment() {
@@ -26,13 +25,13 @@ class RecorderFragment : Fragment() {
         private fun buildFileName() = dateFormat.format(Date(System.currentTimeMillis()))
 
         private const val ARG_PARAM_SESSIONS_PATH = "ARG_PARAM_SESSIONS_PATH"
-		private const val ARG_PARAM_JSON_ROUTE = "ARG_PARAM_JSON_ROUTE"
+        private const val ARG_PARAM_JSON_ROUTE = "ARG_PARAM_JSON_ROUTE"
         val TAG: String = RecorderFragment::class.java.simpleName
 
         fun newInstance(sessionsPath: String, jsonRoute: String?) = RecorderFragment().apply {
             arguments = Bundle().apply {
                 putString(ARG_PARAM_SESSIONS_PATH, sessionsPath)
-				putString(ARG_PARAM_JSON_ROUTE, jsonRoute)
+                putString(ARG_PARAM_JSON_ROUTE, jsonRoute)
             }
         }
     }
@@ -47,7 +46,7 @@ class RecorderFragment : Fragment() {
         return if (baseSessionsPath.isNotEmpty()) {
             val jsonRoute = arguments?.getString(ARG_PARAM_JSON_ROUTE)
             if (jsonRoute != null) {
-                directionsRoute =  DirectionsRoute.fromJson(jsonRoute)
+                directionsRoute = DirectionsRoute.fromJson(jsonRoute)
                 routePoints = directionsRoute?.getRoutePoints() ?: arrayOf()
             }
             inflater.inflate(R.layout.fragment_recorder, container, false)

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/utils/RouteUtils.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/utils/RouteUtils.kt
@@ -1,9 +1,12 @@
 package com.mapbox.vision.teaser.utils
 
+import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.utils.PolylineUtils
 import com.mapbox.vision.ar.core.models.ManeuverType
+import com.mapbox.vision.ar.core.models.RoutePoint
+import com.mapbox.vision.mobile.core.models.position.GeoCoordinate
 
 fun String?.mapToManeuverType(): ManeuverType = when (this) {
     "turn" -> ManeuverType.Turn
@@ -27,4 +30,36 @@ fun String?.mapToManeuverType(): ManeuverType = when (this) {
 
 fun String.buildStepPointsFromGeometry(): List<Point> {
     return PolylineUtils.decode(this, Constants.PRECISION_6)
+}
+
+fun DirectionsRoute.getRoutePoints(): Array<RoutePoint> {
+    val routePoints = arrayListOf<RoutePoint>()
+    legs()?.forEach { leg ->
+        leg.steps()?.forEach { step ->
+            val maneuverPoint = RoutePoint(
+                    GeoCoordinate(
+                            latitude = step.maneuver().location().latitude(),
+                            longitude = step.maneuver().location().longitude()
+                    ),
+                    step.maneuver().type().mapToManeuverType()
+            )
+            routePoints.add(maneuverPoint)
+
+            step.geometry()
+                    ?.buildStepPointsFromGeometry()
+                    ?.map { geometryStep ->
+                        RoutePoint(
+                                GeoCoordinate(
+                                        latitude = geometryStep.latitude(),
+                                        longitude = geometryStep.longitude()
+                                )
+                        )
+                    }
+                    ?.let { stepPoints ->
+                        routePoints.addAll(stepPoints)
+                    }
+        }
+    }
+
+    return routePoints.toTypedArray()
 }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/utils/RouteUtils.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/utils/RouteUtils.kt
@@ -38,8 +38,8 @@ fun DirectionsRoute.getRoutePoints(): Array<RoutePoint> {
         leg.steps()?.forEach { step ->
             val maneuverPoint = RoutePoint(
                     GeoCoordinate(
-                            latitude = step.maneuver().location().latitude(),
-                            longitude = step.maneuver().location().longitude()
+                        latitude = step.maneuver().location().latitude(),
+                        longitude = step.maneuver().location().longitude()
                     ),
                     step.maneuver().type().mapToManeuverType()
             )
@@ -50,8 +50,8 @@ fun DirectionsRoute.getRoutePoints(): Array<RoutePoint> {
                     ?.map { geometryStep ->
                         RoutePoint(
                                 GeoCoordinate(
-                                        latitude = geometryStep.latitude(),
-                                        longitude = geometryStep.longitude()
+                                    latitude = geometryStep.latitude(),
+                                    longitude = geometryStep.longitude()
                                 )
                         )
                     }


### PR DESCRIPTION
PR related to [Zenhub issue](https://app.zenhub.com/workspaces/vision-sdk-5ca52e6c027e3e7234ac7512/issues/mapbox/mapbox-vision/2123)

Implemented in accordance with [Zeplin](https://zpl.io/VxlgZ9w)

Change ArNavigationActivity to return the result as JSON route.
Invoke ArNavigationActivity before Recording.