### PR TITLE
Replay mode empty view (no sessions)

### DIFF
--- a/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
@@ -117,7 +117,7 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
 
         override fun onFrameSignClassificationsUpdated(frameSignClassifications: FrameSignClassifications) {
             if (visionMode == VisionFeature.Classification) {
-                runOnUiThreadIfPossible{
+                runOnUiThreadIfPossible {
                     tracker.update(UiSign.getUiSigns(frameSignClassifications))
                     drawSigns(tracker.getCurrent())
                 }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/replayer/ReplayModeFragment.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/replayer/ReplayModeFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.mapbox.vision.teaser.OnBackPressedListener
 import com.mapbox.vision.teaser.R
+import com.mapbox.vision.teaser.utils.FileUtils
 import java.io.File
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_replay_mode.*
@@ -31,8 +32,6 @@ class ReplayModeFragment : Fragment(), OnBackPressedListener {
 
     private lateinit var sessionsAdapter: SessionsAdapter
     private lateinit var sessionsPath: String
-
-    private fun containsFiles(path: String) = File(path).listFiles().isNotEmpty()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_replay_mode, container, false)
@@ -196,7 +195,7 @@ class ReplayModeFragment : Fragment(), OnBackPressedListener {
     }
 
     private fun activateEmptyStateIfRequired() {
-        val emptyState = !containsFiles(sessionsPath)
+        val emptyState = !FileUtils.isDirectoryContainsFiles(sessionsPath)
         setEmptyState(emptyState)
     }
 

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/replayer/ReplayModeFragment.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/replayer/ReplayModeFragment.kt
@@ -11,8 +11,8 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.mapbox.vision.teaser.OnBackPressedListener
 import com.mapbox.vision.teaser.R
-import kotlinx.android.synthetic.main.activity_main.*
 import java.io.File
+import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_replay_mode.*
 
 class ReplayModeFragment : Fragment(), OnBackPressedListener {

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/utils/FileUtils.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/utils/FileUtils.kt
@@ -1,0 +1,8 @@
+package com.mapbox.vision.teaser.utils
+
+import java.io.File
+
+object FileUtils {
+
+    fun isDirectoryContainsFiles(path: String) = File(path).listFiles().isNotEmpty()
+}

--- a/app/src/main/res/layout/fragment_replay_mode.xml
+++ b/app/src/main/res/layout/fragment_replay_mode.xml
@@ -135,4 +135,33 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <TextView
+        android:id="@+id/no_sessions_title_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="20sp"
+        android:textColor="@color/white"
+        android:lineSpacingExtra="7sp"
+        android:text="@string/replay_mode_no_sessions_title"
+        android:layout_marginBottom="13dp"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintBottom_toTopOf="@id/no_sessions_description_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/no_sessions_description_text"
+        android:layout_width="440dp"
+        android:layout_height="wrap_content"
+        android:textSize="18sp"
+        android:textColor="@color/white"
+        android:lineSpacingExtra="9sp"
+        android:gravity="center_horizontal"
+        android:text="@string/replay_mode_no_sessions_description"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/no_sessions_title_text"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,8 @@
     <string name="camera_text">Camera</string>
     <string name="done_text">Done</string>
     <string name="stop_record">STOP REC</string>
+    <string name="replay_mode_no_sessions_title">There are no any videos to replay</string>
+    <string name="replay_mode_no_sessions_description">You can record them using buid-in recorder or upload it via Mac OS</string>
 
     <plurals name="selected_items">
         <item quantity="one">%d item</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="done_text">Done</string>
     <string name="stop_record">STOP REC</string>
     <string name="replay_mode_no_sessions_title">There are no any videos to replay</string>
-    <string name="replay_mode_no_sessions_description">You can record them using buid-in recorder or upload it via Mac OS</string>
+    <string name="replay_mode_no_sessions_description">You can record them using build-in recorder or upload it via OS</string>
 
     <plurals name="selected_items">
         <item quantity="one">%d item</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="done_text">Done</string>
     <string name="stop_record">STOP REC</string>
     <string name="replay_mode_no_sessions_title">There are no any videos to replay</string>
-    <string name="replay_mode_no_sessions_description">You can record them using build-in recorder or upload it via OS</string>
+    <string name="replay_mode_no_sessions_description">You can record them using built-in recorder or upload it via OS</string>
 
     <plurals name="selected_items">
         <item quantity="one">%d item</item>


### PR DESCRIPTION
PR related to [Zenhub issue](https://app.zenhub.com/workspaces/vision-sdk-5ca52e6c027e3e7234ac7512/issues/mapbox/mapbox-vision/2123)

Implemented in accordance with [Zeplin](https://zpl.io/VxlgZ9w)

Add view with description if there are no pre-recorded sessions

![Screenshot_20200511-192305](https://user-images.githubusercontent.com/7085270/81585557-00d0b000-93bd-11ea-9979-84c920391f06.png)

