### PR TITLE
Move some permissions logic to utlis

### DIFF
--- a/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
@@ -49,12 +49,11 @@ import com.mapbox.vision.teaser.models.UiSign
 import com.mapbox.vision.teaser.recorder.RecorderFragment
 import com.mapbox.vision.teaser.replayer.ArReplayNavigationActivity
 import com.mapbox.vision.teaser.replayer.ReplayModeFragment
+import com.mapbox.vision.teaser.utils.PermissionsUtils
 import com.mapbox.vision.teaser.utils.SoundsPlayer
-import com.mapbox.vision.teaser.utils.allPermissionsGrantedByRequest
 import com.mapbox.vision.teaser.utils.classification.SignResources
 import com.mapbox.vision.teaser.utils.classification.Tracker
 import com.mapbox.vision.teaser.utils.dpToPx
-import com.mapbox.vision.teaser.utils.requestPermissionsIfNotGranted
 import com.mapbox.vision.teaser.view.hide
 import com.mapbox.vision.teaser.view.show
 import com.mapbox.vision.teaser.view.toggleVisibleGone
@@ -343,7 +342,7 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
 
         setContentView(R.layout.activity_main)
 
-        if (!requestPermissionsIfNotGranted()) {
+        if (!PermissionsUtils.requestPermissionsIfNotGranted(this)) {
             onPermissionsGranted()
         }
 
@@ -732,7 +731,7 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (allPermissionsGrantedByRequest(requestCode)) {
+        if (PermissionsUtils.allPermissionsGrantedByRequest(this, requestCode)) {
             onPermissionsGranted()
         }
     }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/MainActivity.kt
@@ -49,11 +49,12 @@ import com.mapbox.vision.teaser.models.UiSign
 import com.mapbox.vision.teaser.recorder.RecorderFragment
 import com.mapbox.vision.teaser.replayer.ArReplayNavigationActivity
 import com.mapbox.vision.teaser.replayer.ReplayModeFragment
-import com.mapbox.vision.teaser.utils.PermissionsUtils
 import com.mapbox.vision.teaser.utils.SoundsPlayer
+import com.mapbox.vision.teaser.utils.allPermissionsGrantedByRequest
 import com.mapbox.vision.teaser.utils.classification.SignResources
 import com.mapbox.vision.teaser.utils.classification.Tracker
 import com.mapbox.vision.teaser.utils.dpToPx
+import com.mapbox.vision.teaser.utils.requestPermissionsIfNotGranted
 import com.mapbox.vision.teaser.view.hide
 import com.mapbox.vision.teaser.view.show
 import com.mapbox.vision.teaser.view.toggleVisibleGone
@@ -342,7 +343,7 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
 
         setContentView(R.layout.activity_main)
 
-        if (!PermissionsUtils.requestPermissionsIfNotGranted(this)) {
+        if (!requestPermissionsIfNotGranted()) {
             onPermissionsGranted()
         }
 
@@ -731,7 +732,7 @@ class MainActivity : AppCompatActivity(), ReplayModeFragment.OnSelectModeItemLis
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (PermissionsUtils.allPermissionsGrantedByRequest(this, requestCode)) {
+        if (allPermissionsGrantedByRequest(requestCode)) {
             onPermissionsGranted()
         }
     }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/replayer/SessionsAdapter.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/replayer/SessionsAdapter.kt
@@ -163,7 +163,7 @@ class SessionsAdapter(
         items.clear()
         items.add(CameraItem(cameraString))
         val files = File(basePath).listFiles() ?: emptyArray()
-        files.sortBy { it.lastModified() }
+        files.sortByDescending { it.lastModified() }
         files.forEach {
             val dateString = dateFormatter.format(it.lastModified())
             items.add(SessionItem(it.name, dateString))

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
@@ -1,0 +1,53 @@
+package com.mapbox.vision.teaser.utils
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+object PermissionsUtils {
+
+    private const val PERMISSION_FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE"
+    private const val PERMISSIONS_REQUEST_CODE = 123
+
+    fun requestPermissionsIfNotGranted(activity: Activity): Boolean {
+        if (!allPermissionsGranted(activity) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            activity.requestPermissions(getRequiredPermissions(activity), PERMISSIONS_REQUEST_CODE)
+            return true
+        }
+        return false
+    }
+
+    private fun allPermissionsGranted(activity: Activity): Boolean {
+        for (permission in getRequiredPermissions(activity)) {
+            if (ContextCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
+                // PERMISSION_FOREGROUND_SERVICE was added for targetSdkVersion >= 28, it is normal and always granted, but should be added to the Manifest file
+                // on devices with Android < P(9) checkSelfPermission(PERMISSION_FOREGROUND_SERVICE) can return PERMISSION_DENIED, but in fact it is GRANTED, so skip it
+                // https://developer.android.com/guide/components/services#Foreground
+                if (permission == PERMISSION_FOREGROUND_SERVICE) {
+                    continue
+                }
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun getRequiredPermissions(activity: Activity): Array<String> {
+        return try {
+            val info = activity.packageManager?.getPackageInfo(activity.packageName, PackageManager.GET_PERMISSIONS)
+            val permissions = info!!.requestedPermissions
+            if (permissions != null && permissions.isNotEmpty()) {
+                permissions
+            } else {
+                emptyArray()
+            }
+        } catch (e: Exception) {
+            emptyArray()
+        }
+    }
+
+    fun allPermissionsGrantedByRequest(activity: Activity, requestCode: Int)
+            = allPermissionsGranted(activity) && requestCode == PERMISSIONS_REQUEST_CODE
+
+}

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
@@ -4,50 +4,47 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
+import com.mapbox.vision.teaser.MainActivity
 
-object PermissionsUtils {
 
-    private const val PERMISSION_FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE"
-    private const val PERMISSIONS_REQUEST_CODE = 123
+private const val PERMISSION_FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE"
+private const val PERMISSIONS_REQUEST_CODE = 123
 
-    fun requestPermissionsIfNotGranted(activity: Activity): Boolean {
-        if (!allPermissionsGranted(activity) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            activity.requestPermissions(getRequiredPermissions(activity), PERMISSIONS_REQUEST_CODE)
-            return true
-        }
-        return false
-    }
-
-    private fun allPermissionsGranted(activity: Activity): Boolean {
-        for (permission in getRequiredPermissions(activity)) {
-            if (ContextCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
-                // PERMISSION_FOREGROUND_SERVICE was added for targetSdkVersion >= 28, it is normal and always granted, but should be added to the Manifest file
-                // on devices with Android < P(9) checkSelfPermission(PERMISSION_FOREGROUND_SERVICE) can return PERMISSION_DENIED, but in fact it is GRANTED, so skip it
-                // https://developer.android.com/guide/components/services#Foreground
-                if (permission == PERMISSION_FOREGROUND_SERVICE) {
-                    continue
-                }
-                return false
-            }
-        }
+fun MainActivity.requestPermissionsIfNotGranted(): Boolean {
+    if (!allPermissionsGranted(this) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        this.requestPermissions(getRequiredPermissions(this), PERMISSIONS_REQUEST_CODE)
         return true
     }
+    return false
+}
 
-    private fun getRequiredPermissions(activity: Activity): Array<String> {
-        return try {
-            val info = activity.packageManager?.getPackageInfo(activity.packageName, PackageManager.GET_PERMISSIONS)
-            val permissions = info!!.requestedPermissions
-            if (permissions != null && permissions.isNotEmpty()) {
-                permissions
-            } else {
-                emptyArray()
+fun MainActivity.allPermissionsGrantedByRequest(requestCode: Int) = allPermissionsGranted(this) && requestCode == PERMISSIONS_REQUEST_CODE
+
+private fun allPermissionsGranted(activity: Activity): Boolean {
+    for (permission in getRequiredPermissions(activity)) {
+        if (ContextCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
+            // PERMISSION_FOREGROUND_SERVICE was added for targetSdkVersion >= 28, it is normal and always granted, but should be added to the Manifest file
+            // on devices with Android < P(9) checkSelfPermission(PERMISSION_FOREGROUND_SERVICE) can return PERMISSION_DENIED, but in fact it is GRANTED, so skip it
+            // https://developer.android.com/guide/components/services#Foreground
+            if (permission == PERMISSION_FOREGROUND_SERVICE) {
+                continue
             }
-        } catch (e: Exception) {
-            emptyArray()
+            return false
         }
     }
+    return true
+}
 
-    fun allPermissionsGrantedByRequest(activity: Activity, requestCode: Int)
-            = allPermissionsGranted(activity) && requestCode == PERMISSIONS_REQUEST_CODE
-
+private fun getRequiredPermissions(activity: Activity): Array<String> {
+    return try {
+        val info = activity.packageManager?.getPackageInfo(activity.packageName, PackageManager.GET_PERMISSIONS)
+        val permissions = info!!.requestedPermissions
+        if (permissions != null && permissions.isNotEmpty()) {
+            permissions
+        } else {
+            emptyArray()
+        }
+    } catch (e: Exception) {
+        emptyArray()
+    }
 }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
@@ -4,46 +4,50 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
-import com.mapbox.vision.teaser.MainActivity
 
-private const val PERMISSION_FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE"
-private const val PERMISSIONS_REQUEST_CODE = 123
+object PermissionsUtils {
 
-fun MainActivity.requestPermissionsIfNotGranted(): Boolean {
-    if (!allPermissionsGranted(this) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        this.requestPermissions(getRequiredPermissions(this), PERMISSIONS_REQUEST_CODE)
+    private const val PERMISSION_FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE"
+    private const val PERMISSIONS_REQUEST_CODE = 123
+
+    fun requestPermissionsIfNotGranted(activity: Activity): Boolean {
+        if (!allPermissionsGranted(activity) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            activity.requestPermissions(getRequiredPermissions(activity), PERMISSIONS_REQUEST_CODE)
+            return true
+        }
+        return false
+    }
+
+    private fun allPermissionsGranted(activity: Activity): Boolean {
+        for (permission in getRequiredPermissions(activity)) {
+            if (ContextCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
+                // PERMISSION_FOREGROUND_SERVICE was added for targetSdkVersion >= 28, it is normal and always granted, but should be added to the Manifest file
+                // on devices with Android < P(9) checkSelfPermission(PERMISSION_FOREGROUND_SERVICE) can return PERMISSION_DENIED, but in fact it is GRANTED, so skip it
+                // https://developer.android.com/guide/components/services#Foreground
+                if (permission == PERMISSION_FOREGROUND_SERVICE) {
+                    continue
+                }
+                return false
+            }
+        }
         return true
     }
-    return false
-}
 
-fun MainActivity.allPermissionsGrantedByRequest(requestCode: Int) = allPermissionsGranted(this) && requestCode == PERMISSIONS_REQUEST_CODE
-
-private fun allPermissionsGranted(activity: Activity): Boolean {
-    for (permission in getRequiredPermissions(activity)) {
-        if (ContextCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
-            // PERMISSION_FOREGROUND_SERVICE was added for targetSdkVersion >= 28, it is normal and always granted, but should be added to the Manifest file
-            // on devices with Android < P(9) checkSelfPermission(PERMISSION_FOREGROUND_SERVICE) can return PERMISSION_DENIED, but in fact it is GRANTED, so skip it
-            // https://developer.android.com/guide/components/services#Foreground
-            if (permission == PERMISSION_FOREGROUND_SERVICE) {
-                continue
+    private fun getRequiredPermissions(activity: Activity): Array<String> {
+        return try {
+            val info = activity.packageManager?.getPackageInfo(activity.packageName, PackageManager.GET_PERMISSIONS)
+            val permissions = info?.requestedPermissions
+            if (permissions != null && permissions.isNotEmpty()) {
+                permissions
+            } else {
+                emptyArray()
             }
-            return false
-        }
-    }
-    return true
-}
-
-private fun getRequiredPermissions(activity: Activity): Array<String> {
-    return try {
-        val info = activity.packageManager?.getPackageInfo(activity.packageName, PackageManager.GET_PERMISSIONS)
-        val permissions = info!!.requestedPermissions
-        if (permissions != null && permissions.isNotEmpty()) {
-            permissions
-        } else {
+        } catch (e: Exception) {
             emptyArray()
         }
-    } catch (e: Exception) {
-        emptyArray()
     }
+
+    fun allPermissionsGrantedByRequest(activity: Activity, requestCode: Int)
+            = allPermissionsGranted(activity) && requestCode == PERMISSIONS_REQUEST_CODE
+
 }

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
@@ -6,7 +6,6 @@ import android.os.Build
 import androidx.core.content.ContextCompat
 import com.mapbox.vision.teaser.MainActivity
 
-
 private const val PERMISSION_FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE"
 private const val PERMISSIONS_REQUEST_CODE = 123
 

--- a/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
+++ b/app/src/main/kotlin/com/mapbox/vision/teaser/utils/PermissionsUtils.kt
@@ -4,13 +4,14 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
+import com.mapbox.vision.teaser.MainActivity
 
 object PermissionsUtils {
 
     private const val PERMISSION_FOREGROUND_SERVICE = "android.permission.FOREGROUND_SERVICE"
     private const val PERMISSIONS_REQUEST_CODE = 123
 
-    fun requestPermissionsIfNotGranted(activity: Activity): Boolean {
+    fun requestPermissionsIfNotGranted(activity: MainActivity): Boolean {
         if (!allPermissionsGranted(activity) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             activity.requestPermissions(getRequiredPermissions(activity), PERMISSIONS_REQUEST_CODE)
             return true
@@ -18,7 +19,7 @@ object PermissionsUtils {
         return false
     }
 
-    private fun allPermissionsGranted(activity: Activity): Boolean {
+    private fun allPermissionsGranted(activity: MainActivity): Boolean {
         for (permission in getRequiredPermissions(activity)) {
             if (ContextCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
                 // PERMISSION_FOREGROUND_SERVICE was added for targetSdkVersion >= 28, it is normal and always granted, but should be added to the Manifest file
@@ -33,7 +34,7 @@ object PermissionsUtils {
         return true
     }
 
-    private fun getRequiredPermissions(activity: Activity): Array<String> {
+    private fun getRequiredPermissions(activity: MainActivity): Array<String> {
         return try {
             val info = activity.packageManager?.getPackageInfo(activity.packageName, PackageManager.GET_PERMISSIONS)
             val permissions = info?.requestedPermissions
@@ -47,7 +48,7 @@ object PermissionsUtils {
         }
     }
 
-    fun allPermissionsGrantedByRequest(activity: Activity, requestCode: Int)
+    fun allPermissionsGrantedByRequest(activity: MainActivity, requestCode: Int)
             = allPermissionsGranted(activity) && requestCode == PERMISSIONS_REQUEST_CODE
 
 }


### PR DESCRIPTION
Move code of permissions to separate class because it doesn't reflect main purpose of teaser to show Vision SDK usage