### PR TITLE
Use sdk registry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,25 +28,16 @@ allprojects {
         maven { url 'https://mapbox.bintray.com/mapbox' }
 
         maven {
-            credentials {
-                username project.properties['mapboxMavenUser'] ?: ""
-                password project.properties['mapboxMavenToken'] ?: ""
-            }
+            url 'https://api.mapbox.com/downloads/v2/releases/maven'
             authentication {
                 basic(BasicAuthentication)
             }
-
-            url 'https://api.mapbox.com/downloads/v1/vision/android/maven'
-        }
-
-        if (gradle.ext.has('BUILD_CORE_FROM_SOURCE')) {
-            maven {
-                credentials {
-                    username project.properties['bintrayUser'] ?: System.getenv("MAPBOX_BINTRAY_PRIVATE_USER") ?: ""
-                    password project.properties['bintrayApiKey'] ?: System.getenv("MAPBOX_BINTRAY_PRIVATE_TOKEN") ?: ""
-                }
-
-                url 'https://mapbox.bintray.com/mapbox_private'
+            credentials {
+                // Do not change the username below.
+                // This should always be `mapbox` (not your username).
+                username = 'mapbox'
+                // Use the secret token you stored in gradle.properties as the password
+                password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ""
             }
         }
     }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -2,7 +2,7 @@ ext {
     gradle_plugin = '3.6.3'
     android_sdk_versions_plugin = '1.0.0'
 
-    dokka_version = '1.4.30'
+    dokka_version = '0.9.18'
     kotlin_version = '1.4.30'
 
     min_sdk_version = 23
@@ -26,7 +26,7 @@ ext {
     mannodermaus_junit5_version = '1.6.0.0'
     gradle_pitest_plugin_version = '0.2.1'
 
-    ktlint_version = '0.36.0'
+    ktlint_version = '0.41.0'
     android_sdk_versions_plugin = '1.0.0'
 
     google_gms_services_version = '4.3.5'


### PR DESCRIPTION
Since downloads API v1 (`https://api.mapbox.com/downloads/v1/vision/android/maven`) is no longer working we've transferred all previously released vision versions to the SDK registry (`https://api.mapbox.com/downloads/v2/releases/maven`).

NOTE : with this change you'll need a new token with `Downloads:Read` scope to access Vision.
I've also aligned naming with the rest of mapbox SDKs - it became `MAPBOX_DOWNLOADS_TOKEN` (https://docs.mapbox.com/android/maps/guides/install/ / https://docs.mapbox.com/android/navigation/guides/install/). 